### PR TITLE
Automatic transformation of Docker-based topologies into Slurm/Singularity 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
   </build>

--- a/src/main/java-templates/alien4cloud/paas/yorc/Versions.java
+++ b/src/main/java-templates/alien4cloud/paas/yorc/Versions.java
@@ -1,0 +1,9 @@
+package alien4cloud.paas.yorc;
+
+
+/**
+ * Contains plugin versions.
+ */
+public class Versions {
+    public static final String SLURM_CSAR_VERSION = "${yorc.slurm.types.version}";
+}

--- a/src/main/java/alien4cloud/paas/yorc/modifier/DockerToSingularityModifier.java
+++ b/src/main/java/alien4cloud/paas/yorc/modifier/DockerToSingularityModifier.java
@@ -1,0 +1,269 @@
+package alien4cloud.paas.yorc.modifier;
+
+import static alien4cloud.paas.yorc.Versions.SLURM_CSAR_VERSION;
+import static alien4cloud.utils.AlienUtils.safe;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.alien4cloud.alm.deployment.configuration.flow.FlowExecutionContext;
+import org.alien4cloud.alm.deployment.configuration.flow.TopologyModifierSupport;
+import org.alien4cloud.tosca.editor.operations.nodetemplate.DeleteNodeOperation;
+import org.alien4cloud.tosca.model.Csar;
+import org.alien4cloud.tosca.model.definitions.AbstractPropertyValue;
+import org.alien4cloud.tosca.model.definitions.ComplexPropertyValue;
+import org.alien4cloud.tosca.model.definitions.ImplementationArtifact;
+import org.alien4cloud.tosca.model.definitions.Interface;
+import org.alien4cloud.tosca.model.definitions.ListPropertyValue;
+import org.alien4cloud.tosca.model.definitions.Operation;
+import org.alien4cloud.tosca.model.templates.NodeTemplate;
+import org.alien4cloud.tosca.model.templates.Topology;
+import org.alien4cloud.tosca.model.types.NodeType;
+import org.alien4cloud.tosca.utils.InterfaceUtils;
+import org.alien4cloud.tosca.utils.TopologyNavigationUtil;
+import org.springframework.stereotype.Component;
+
+import alien4cloud.paas.plan.ToscaNodeLifecycleConstants;
+import alien4cloud.paas.wf.validation.WorkflowValidator;
+import alien4cloud.tosca.context.ToscaContext;
+import alien4cloud.utils.PropertyUtil;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component(value = DockerToSingularityModifier.D2S_MODIFIER_TAG)
+public class DockerToSingularityModifier extends TopologyModifierSupport {
+
+    public static final String D2S_MODIFIER_TAG = "docker-to-singularity-modifier";
+
+    public static final String A4C_D2S_MODIFIER_TAG = "a4c_docker-to-singularity-modifier";
+    public static final String A4C_TYPES_APPLICATION_DOCKER_CONTAINER = "tosca.nodes.Container.Application.DockerContainer";
+
+    public static final String SLURM_TYPES_CONTAINER_RUNTIME = "yorc.nodes.slurm.ContainerRuntime";
+    public static final String SLURM_TYPES_CONTAINER_JOB_UNIT = "yorc.nodes.slurm.ContainerJobUnit";
+    public static final String SLURM_TYPES_SINGULARITY_JOB = "yorc.nodes.slurm.SingularityJob";
+
+    public static final String A4C_RUNNABLE_INTERFACE_NAME = "tosca.interfaces.node.lifecycle.Runnable";
+    public static final String A4C_SUBMIT_OPERATION_NAME = "submit";
+    public static final String A4C_SLURM_JOB_IMAGE_ARTIFACT_TYPE = "yorc.artifacts.Deployment.SlurmJobImage";
+
+    public static final String A4C_NODES_REPLACEMENT_CACHE_KEY = "a4c_docker2singularity_nodes_replacement_key";
+
+    @Override
+    public void process(Topology topology, FlowExecutionContext context) {
+        log.info("Processing topology {}", topology.getId());
+
+        try {
+            WorkflowValidator.disableValidationThreadLocal.set(true);
+            doProcess(topology, context);
+        } catch (Exception e) {
+            context.getLog().error("Couldn't process " + A4C_D2S_MODIFIER_TAG);
+            log.warn("Couldn't process {}", A4C_D2S_MODIFIER_TAG, e);
+        } finally {
+            WorkflowValidator.disableValidationThreadLocal.remove();
+        }
+
+    }
+
+    private void doProcess(Topology topology, FlowExecutionContext context) {
+        Csar csar = new Csar(topology.getArchiveName(), topology.getArchiveVersion());
+        if (context.getEnvironmentContext().isPresent()) {
+            csar.setName(csar.getName() + "-" + context.getEnvironmentContext().get().getEnvironment().getName());
+        }
+
+        // replace all yorc.nodes.slurm.ContainerJobUnit by
+        // yorc.nodes.slurm.SingularityJob
+        Set<NodeTemplate> containerJobUnitNodes = TopologyNavigationUtil.getNodesOfType(topology,
+                SLURM_TYPES_CONTAINER_JOB_UNIT, false);
+        containerJobUnitNodes.forEach(nodeTemplate -> transformContainerJobUnit(csar, topology, context, nodeTemplate));
+
+        // replace all yorc.nodes.slurm.ContainerJobUnit by
+        // yorc.nodes.slurm.SingularityJob if not already hosted on a ContainerJobUnit
+        Set<NodeTemplate> containerRuntimeNodes = TopologyNavigationUtil.getNodesOfType(topology,
+                SLURM_TYPES_CONTAINER_RUNTIME, false);
+        containerRuntimeNodes.forEach(nodeTemplate -> transformContainerRuntime(csar, topology, context, nodeTemplate));
+
+        // replace all tosca.nodes.Container.Application.DockerContainer by
+        // yorc.nodes.slurm.SingularityJob if hosted on a ContainerRuntime transformed
+        // into a yorc.nodes.slurm.SingularityJob
+        Set<NodeTemplate> containerNodes = TopologyNavigationUtil.getNodesOfType(topology,
+                A4C_TYPES_APPLICATION_DOCKER_CONTAINER, true);
+        containerNodes.forEach(nodeTemplate -> transformContainer(csar, topology, context, nodeTemplate));
+
+        // Remove replaced nodes
+        Map<String, NodeTemplate> replacementMap = (Map<String, NodeTemplate>) context.getExecutionCache()
+                .get(A4C_NODES_REPLACEMENT_CACHE_KEY);
+
+        safe(replacementMap.keySet()).forEach(nodeName -> removeNode(csar, topology, nodeName));
+    }
+
+    private void removeNode(Csar csar, Topology topology, String nodeName) {
+        DeleteNodeOperation deleteNodeOperation = new DeleteNodeOperation();
+        deleteNodeOperation.setNodeName(nodeName);
+        deleteNodeProcessor.process(csar, topology, deleteNodeOperation);
+    }
+
+    private void addToReplacementMap(FlowExecutionContext context, NodeTemplate initialNode,
+            NodeTemplate replacementNode) {
+        Map<String, NodeTemplate> replacementMap = (Map<String, NodeTemplate>) context.getExecutionCache()
+                .get(A4C_NODES_REPLACEMENT_CACHE_KEY);
+        if (replacementMap == null) {
+            replacementMap = new HashMap<>();
+            context.getExecutionCache().put(A4C_NODES_REPLACEMENT_CACHE_KEY, replacementMap);
+        }
+        replacementMap.put(initialNode.getName(), replacementNode);
+
+    }
+
+    /**
+     * Replace this node of type ContainerJobUnit by a node of type
+     * yorc.nodes.slurm.SingularityJob.
+     */
+    private void transformContainerJobUnit(Csar csar, Topology topology, FlowExecutionContext context,
+            NodeTemplate nodeTemplate) {
+        NodeTemplate singularityNode = addNodeTemplate(csar, topology, nodeTemplate.getName() + "_Singularity",
+                SLURM_TYPES_SINGULARITY_JOB, SLURM_CSAR_VERSION);
+        addToReplacementMap(context, nodeTemplate, singularityNode);
+        setNodeTagValue(singularityNode, A4C_D2S_MODIFIER_TAG + "_created_from", nodeTemplate.getName());
+
+        // TODO take into account transformation
+    }
+
+    /**
+     * Replace this node of type ContainerRuntime by a node of type
+     * yorc.nodes.slurm.SingularityJob.
+     */
+    private void transformContainerRuntime(Csar csar, Topology topology, FlowExecutionContext context,
+            NodeTemplate nodeTemplate) {
+
+        NodeTemplate jobUnitNode = TopologyNavigationUtil.getHostOfTypeInHostingHierarchy(topology, nodeTemplate,
+                SLURM_TYPES_CONTAINER_JOB_UNIT);
+
+        if (jobUnitNode == null) {
+            log.debug("Ignoring ContainerRuntime node <{}> not hosted on a ContainerJobUnit", nodeTemplate.getName());
+            return;
+        }
+        Map<String, NodeTemplate> replacementMap = (Map<String, NodeTemplate>) context.getExecutionCache()
+                .get(A4C_NODES_REPLACEMENT_CACHE_KEY);
+        NodeTemplate singularityNode = replacementMap.get(jobUnitNode.getName());
+        String tagValue = getNodeTagValueOrNull(singularityNode, A4C_D2S_MODIFIER_TAG + "_created_from");
+        tagValue += "," + nodeTemplate.getName();
+        setNodeTagValue(singularityNode, A4C_D2S_MODIFIER_TAG + "_created_from", tagValue);
+        // Mark as replaced by the singularity job
+        addToReplacementMap(context, nodeTemplate, singularityNode);
+
+        // TODO take into account transformation
+
+    }
+
+    /**
+     * Replace this node of type DockerContainer by a node of type
+     * yorc.nodes.slurm.SingularityJob.
+     */
+    private void transformContainer(Csar csar, Topology topology, FlowExecutionContext context,
+            NodeTemplate nodeTemplate) {
+
+        NodeTemplate jobUnitNode = TopologyNavigationUtil.getHostOfTypeInHostingHierarchy(topology, nodeTemplate,
+                SLURM_TYPES_CONTAINER_JOB_UNIT);
+
+        if (jobUnitNode == null) {
+            log.debug("Ignoring DockerContainer node <{}> not hosted on a ContainerJobUnit", nodeTemplate.getName());
+            return;
+        }
+
+        Map<String, NodeTemplate> replacementMap = (Map<String, NodeTemplate>) context.getExecutionCache()
+                .get(A4C_NODES_REPLACEMENT_CACHE_KEY);
+        NodeTemplate singularityNode = replacementMap.get(jobUnitNode.getName());
+        String tagValue = getNodeTagValueOrNull(singularityNode, A4C_D2S_MODIFIER_TAG + "_created_from");
+        tagValue += "," + nodeTemplate.getName();
+        setNodeTagValue(singularityNode, A4C_D2S_MODIFIER_TAG + "_created_from", tagValue);
+        // Mark as replaced by the singularity job
+        addToReplacementMap(context, nodeTemplate, singularityNode);
+
+        // TODO take into account transformation
+
+        transformContainerOperation(csar, context, nodeTemplate, singularityNode);
+        transformContainerProperties(csar, topology, context, nodeTemplate, singularityNode);
+
+    }
+
+    private void transformContainerOperation(Csar csar, FlowExecutionContext context, NodeTemplate container,
+            NodeTemplate singularityNode) {
+        Operation op = getContainerImageOperation(container);
+        if (op == null) {
+            context.getLog()
+                    .error("Container image is missing on standard.create operation of <" + container.getName() + ">");
+            return;
+        }
+
+        Interface runnable = new Interface(A4C_RUNNABLE_INTERFACE_NAME);
+        ImplementationArtifact dockerImageImpl = new ImplementationArtifact(
+                "docker://" + op.getImplementationArtifact().getArtifactRef());
+        dockerImageImpl.setArtifactRepository(op.getImplementationArtifact().getArtifactRepository());
+        dockerImageImpl.setArchiveName(csar.getName());
+        dockerImageImpl.setArchiveVersion(csar.getVersion());
+        dockerImageImpl.setRepositoryName(op.getImplementationArtifact().getRepositoryName());
+        dockerImageImpl.setRepositoryURL(op.getImplementationArtifact().getRepositoryURL());
+        dockerImageImpl.setRepositoryCredential(op.getImplementationArtifact().getRepositoryCredential());
+        dockerImageImpl.setArtifactType(A4C_SLURM_JOB_IMAGE_ARTIFACT_TYPE);
+        Operation submit = new Operation(dockerImageImpl);
+        runnable.setOperations(new HashMap<>());
+        runnable.getOperations().put(A4C_SUBMIT_OPERATION_NAME, submit);
+        singularityNode.setInterfaces(new HashMap<>());
+        singularityNode.getInterfaces().put(A4C_RUNNABLE_INTERFACE_NAME, runnable);
+
+    }
+
+    public static Operation getContainerImageOperation(NodeTemplate nodeTemplate) {
+        Operation imageOperation = InterfaceUtils.getOperationIfArtifactDefined(nodeTemplate.getInterfaces(),
+                ToscaNodeLifecycleConstants.STANDARD, ToscaNodeLifecycleConstants.CREATE);
+        if (imageOperation != null) {
+            return imageOperation;
+        }
+        // if not overriden in the template, fetch from the type.
+        NodeType nodeType = ToscaContext.get(NodeType.class, nodeTemplate.getType());
+        imageOperation = InterfaceUtils.getOperationIfArtifactDefined(nodeType.getInterfaces(),
+                ToscaNodeLifecycleConstants.STANDARD, ToscaNodeLifecycleConstants.CREATE);
+        return imageOperation;
+    }
+
+    private void transformContainerProperties(Csar csar, Topology topology, FlowExecutionContext context,
+            NodeTemplate container, NodeTemplate singularityNode) {
+        Map<String, AbstractPropertyValue> properties = container.getProperties();
+        if (properties == null) {
+            return;
+        }
+        transformContainerCommand(csar, topology, context, properties, singularityNode);
+        transformContainerEnv(csar, topology, context, properties, singularityNode);
+    }
+
+    private void transformContainerCommand(Csar csar, Topology topology, FlowExecutionContext context,
+            Map<String, AbstractPropertyValue> properties, NodeTemplate singularityNode) {
+
+        AbstractPropertyValue dockerRunCmdProp = PropertyUtil.getPropertyValueFromPath(properties, "docker_run_cmd");
+        if (dockerRunCmdProp != null) {
+            // Should be both of the same type "scalar"
+            setNodePropertyPathValue(csar, topology, singularityNode, "execution_options.command", dockerRunCmdProp);
+        }
+        AbstractPropertyValue dockerRunArgsProp = PropertyUtil.getPropertyValueFromPath(properties, "docker_run_args");
+        if (dockerRunArgsProp != null) {
+            // Should be both of the same type "scalar"
+            setNodePropertyPathValue(csar, topology, singularityNode, "execution_options.args", dockerRunArgsProp);
+        }
+    }
+    private void transformContainerEnv(Csar csar, Topology topology, FlowExecutionContext context,
+            Map<String, AbstractPropertyValue> properties, NodeTemplate singularityNode) {
+                AbstractPropertyValue dockerEnvVarsProp = PropertyUtil.getPropertyValueFromPath(properties, "docker_env_vars");
+                if (dockerEnvVarsProp instanceof ComplexPropertyValue) {
+                    // Convert map to list of string in k=v form
+                    ComplexPropertyValue mapProps = (ComplexPropertyValue)dockerEnvVarsProp;
+                    ListPropertyValue singEnvVarsProp = new ListPropertyValue(new ArrayList<>());
+                    for (Entry<String, Object> varEntry : safe(mapProps.getValue()).entrySet()) {
+                        singEnvVarsProp.getValue().add(varEntry.getKey()+"="+varEntry.getValue().toString());
+                    }
+                    setNodePropertyPathValue(csar, topology, singularityNode, "execution_options.env_vars", singEnvVarsProp);
+                }
+            }
+}

--- a/src/main/java/alien4cloud/paas/yorc/modifier/DockerToSingularityModifier.java
+++ b/src/main/java/alien4cloud/paas/yorc/modifier/DockerToSingularityModifier.java
@@ -125,12 +125,12 @@ public class DockerToSingularityModifier extends TopologyModifierSupport {
 
     private void linkDependsOn(Csar csar, FlowExecutionContext context, Topology topology,
             Map<String, String> containersDependencies, Map<String, NodeTemplate> replacementMap) {
-                containersDependencies.forEach((source, target) -> {
-                    NodeTemplate sourceNode = replacementMap.get(source);
-                    NodeTemplate targetNode = replacementMap.get(target);
-                    addRelationshipTemplate(csar, topology, sourceNode, targetNode.getName(),
+        containersDependencies.forEach((source, target) -> {
+            NodeTemplate sourceNode = replacementMap.get(source);
+            NodeTemplate targetNode = replacementMap.get(target);
+            addRelationshipTemplate(csar, topology, sourceNode, targetNode.getName(),
                     NormativeRelationshipConstants.DEPENDS_ON, "dependency", "feature");
-                });
+        });
     }
 
     private void removeNode(Csar csar, Topology topology, String nodeName) {
@@ -237,7 +237,8 @@ public class DockerToSingularityModifier extends TopologyModifierSupport {
 
         Map<String, String> containersDependencies = (Map<String, String>) context.getExecutionCache()
                 .get(A4C_NODES_DEPENDS_ON_CACHE_KEY);
-        Set<NodeTemplate> dependents = TopologyNavigationUtil.getSourceNodesByRelationshipType(topology, nodeTemplate, NormativeRelationshipConstants.DEPENDS_ON);
+        Set<NodeTemplate> dependents = TopologyNavigationUtil.getSourceNodesByRelationshipType(topology, nodeTemplate,
+                NormativeRelationshipConstants.DEPENDS_ON);
         dependents.forEach(sourceNode -> containersDependencies.put(sourceNode.getName(), nodeTemplate.getName()));
     }
 

--- a/src/main/java/alien4cloud/paas/yorc/modifier/DockerToSingularityModifier.java
+++ b/src/main/java/alien4cloud/paas/yorc/modifier/DockerToSingularityModifier.java
@@ -192,6 +192,8 @@ public class DockerToSingularityModifier extends TopologyModifierSupport {
         // Mark as replaced by the singularity job
         addToReplacementMap(context, nodeTemplate, singularityNode);
 
+
+
     }
 
     /**
@@ -285,7 +287,7 @@ public class DockerToSingularityModifier extends TopologyModifierSupport {
         // Mark as replaced by the singularity job
         addToReplacementMap(context, nodeTemplate, singularityNode);
 
-        // TODO take into account transformation
+        setNodePropertyPathValue(csar, topology, singularityNode, "slurm_options.name", new ScalarPropertyValue(singularityNode.getName()));
 
         transformContainerOperation(csar, context, functionEvaluatorContext, topology, nodeTemplate, singularityNode);
         transformContainerProperties(csar, topology, context, nodeTemplate, singularityNode);

--- a/src/main/java/alien4cloud/paas/yorc/modifier/util/InputsHelper.java
+++ b/src/main/java/alien4cloud/paas/yorc/modifier/util/InputsHelper.java
@@ -1,0 +1,75 @@
+package alien4cloud.paas.yorc.modifier.util;
+
+import org.alien4cloud.alm.deployment.configuration.flow.FlowExecutionContext;
+import org.alien4cloud.tosca.model.definitions.AbstractPropertyValue;
+import org.alien4cloud.tosca.model.definitions.ConcatPropertyValue;
+import org.alien4cloud.tosca.model.definitions.PropertyValue;
+import org.alien4cloud.tosca.model.definitions.ScalarPropertyValue;
+import org.alien4cloud.tosca.model.templates.NodeTemplate;
+import org.alien4cloud.tosca.model.templates.Topology;
+import org.alien4cloud.tosca.utils.FunctionEvaluator;
+import org.alien4cloud.tosca.utils.FunctionEvaluatorContext;
+
+import alien4cloud.utils.PropertyUtil;
+
+/**
+ * InputsHelper
+ */
+public class InputsHelper {
+
+    /**
+     * Resolve an input of a given nodeTemplate
+     * @param topology The {@code Topology} holding the given {@code NodeTemplate}
+     * @param nodeTemplate The given {@code NodeTemplate} holding the input
+     * @param functionEvaluatorContext The {@code FunctionEvaluatorContext} used to evaluate functions
+     * @param inputName the input name
+     * @param iValue the value of this input
+     * @param context A {@code FlowExecutionContext} coming from Topologies Modifiers
+     * @return The resolved {@code AbstractPropertyValue} or {@code null}
+     */
+    public static AbstractPropertyValue resolveInput(Topology topology, NodeTemplate nodeTemplate,
+            FunctionEvaluatorContext functionEvaluatorContext, String inputName, AbstractPropertyValue iValue,
+            FlowExecutionContext context) {
+        if (iValue instanceof ConcatPropertyValue) {
+            ConcatPropertyValue cpv = (ConcatPropertyValue) iValue;
+            StringBuilder sb = new StringBuilder();
+            for (AbstractPropertyValue param : cpv.getParameters()) {
+                AbstractPropertyValue v = resolveInput(topology, nodeTemplate, functionEvaluatorContext, inputName,
+                        param, context);
+                if (v instanceof ScalarPropertyValue) {
+                    sb.append(PropertyUtil.getScalarValue(v));
+                } else {
+                    context.getLog()
+                            .warn("Some element in concat operation for input <" + inputName + "> ("
+                                    + PropertiesHelper.serializePropertyValue(param) + ") of container <"
+                                    + nodeTemplate.getName() + "> resolved to a complex result. Let's ignore it.");
+                }
+            }
+            return new ScalarPropertyValue(sb.toString());
+        }
+        if (PropertiesHelper.isTargetedEndpointProperty(topology, nodeTemplate, iValue)) {
+            return PropertiesHelper.getTargetedEndpointProperty(topology, nodeTemplate, iValue);
+        }
+
+        try {
+            AbstractPropertyValue propertyValue = FunctionEvaluator.tryResolveValue(functionEvaluatorContext,
+                    nodeTemplate, nodeTemplate.getProperties(), iValue);
+            if (propertyValue != null) {
+                if (propertyValue instanceof PropertyValue) {
+                    return propertyValue;
+                } else {
+                    context.getLog()
+                            .warn("Property is not PropertyValue but <" + propertyValue.getClass() + "> for input <"
+                                    + inputName + "> (" + PropertiesHelper.serializePropertyValue(propertyValue)
+                                    + ") of container <" + nodeTemplate.getName() + ">");
+                }
+            }
+        } catch (IllegalArgumentException iae) {
+            context.getLog()
+                    .warn("Can't resolve value for input <" + inputName + "> ("
+                            + PropertiesHelper.serializePropertyValue(iValue) + ") of container <"
+                            + nodeTemplate.getName() + ">, error was : " + iae.getMessage());
+        }
+        return null;
+    }
+}

--- a/src/main/java/alien4cloud/paas/yorc/modifier/util/PropertiesHelper.java
+++ b/src/main/java/alien4cloud/paas/yorc/modifier/util/PropertiesHelper.java
@@ -1,0 +1,91 @@
+package alien4cloud.paas.yorc.modifier.util;
+
+import java.util.Set;
+
+import org.alien4cloud.tosca.model.definitions.AbstractPropertyValue;
+import org.alien4cloud.tosca.model.definitions.FunctionPropertyValue;
+import org.alien4cloud.tosca.model.definitions.IValue;
+import org.alien4cloud.tosca.model.definitions.ScalarPropertyValue;
+import org.alien4cloud.tosca.model.templates.Capability;
+import org.alien4cloud.tosca.model.templates.NodeTemplate;
+import org.alien4cloud.tosca.model.templates.RelationshipTemplate;
+import org.alien4cloud.tosca.model.templates.ServiceNodeTemplate;
+import org.alien4cloud.tosca.model.templates.Topology;
+import org.alien4cloud.tosca.normative.constants.ToscaFunctionConstants;
+import org.alien4cloud.tosca.utils.TopologyNavigationUtil;
+
+import alien4cloud.tosca.serializer.ToscaPropertySerializerUtils;
+import alien4cloud.utils.PropertyUtil;
+
+/**
+ * PropertiesHelper
+ */
+public class PropertiesHelper {
+
+    /**
+     * Serialize a given {@code AbstractPropertyValue} into a string
+     *
+     * @param value the value to serialize
+     * @return value serialized into a string
+     */
+    public static String serializePropertyValue(AbstractPropertyValue value) {
+        try {
+            return ToscaPropertySerializerUtils.formatPropertyValue(0, value);
+        } catch (Exception e) {
+            return "Serialization not possible : " + e.getMessage();
+        }
+    }
+
+    /**
+     * For a given node template, if the inputParameterValue value is a function if
+     * of type get_attribute(TARGET, requirement, property) and the target is a
+     * docker container, return true if the targeted capability has this property.
+     */
+    public static boolean isTargetedEndpointProperty(Topology topology, NodeTemplate sourceNodeTemplate,
+            IValue inputParameterValue) {
+        AbstractPropertyValue abstractPropertyValue = getTargetedEndpointProperty(topology, sourceNodeTemplate,
+                inputParameterValue);
+        return abstractPropertyValue != null;
+    }
+
+    /**
+     * For a given node template, if the inputParameterValue value is a function if
+     * of type get_attribute(TARGET, requirement, property) and the target is a
+     * docker container, return the value of the property.
+     */
+    public static AbstractPropertyValue getTargetedEndpointProperty(Topology topology, NodeTemplate sourceNodeTemplate,
+            IValue inputParameterValue) {
+        // a get_attribute that searchs an ip_address on a requirement that targets a
+        // Docker Container should return true
+        if (inputParameterValue instanceof FunctionPropertyValue) {
+            FunctionPropertyValue evaluatedFunction = (FunctionPropertyValue) inputParameterValue;
+            if (evaluatedFunction.getFunction().equals(ToscaFunctionConstants.GET_ATTRIBUTE)
+                    && evaluatedFunction.getTemplateName().equals(ToscaFunctionConstants.R_TARGET)) {
+                String requirement = evaluatedFunction.getCapabilityOrRequirementName();
+                if (requirement != null) {
+                    Set<RelationshipTemplate> targetRelationships = TopologyNavigationUtil
+                            .getTargetRelationships(sourceNodeTemplate, requirement);
+                    for (RelationshipTemplate targetRelationship : targetRelationships) {
+                        NodeTemplate targetNode = topology.getNodeTemplates().get(targetRelationship.getTarget());
+                        Capability endpoint = targetNode.getCapabilities()
+                                .get(targetRelationship.getTargetedCapabilityName());
+                        String attributeName = "capabilities." + targetRelationship.getTargetedCapabilityName() + "."
+                                + evaluatedFunction.getElementNameToFetch();
+                        if (targetNode instanceof ServiceNodeTemplate
+                                && ((ServiceNodeTemplate) targetNode).getAttributeValues().containsKey(attributeName)) {
+                            return new ScalarPropertyValue(
+                                    ((ServiceNodeTemplate) targetNode).getAttributeValues().get(attributeName));
+                        } else {
+                            AbstractPropertyValue targetPropertyValue = PropertyUtil.getPropertyValueFromPath(
+                                    endpoint.getProperties(), evaluatedFunction.getElementNameToFetch());
+                            if (targetPropertyValue != null) {
+                                return targetPropertyValue;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/alien4cloud/paas/yorc/service/ZipBuilder.java
+++ b/src/main/java/alien4cloud/paas/yorc/service/ZipBuilder.java
@@ -1,28 +1,10 @@
 package alien4cloud.paas.yorc.service;
 
-import alien4cloud.component.ICSARRepositorySearchService;
-import alien4cloud.model.components.CSARSource;
-import alien4cloud.model.deployment.DeploymentTopology;
-import alien4cloud.paas.model.PaaSNodeTemplate;
-import alien4cloud.paas.model.PaaSTopology;
-import alien4cloud.paas.model.PaaSTopologyDeploymentContext;
-import alien4cloud.paas.yorc.tosca.model.templates.YorcServiceNodeTemplate;
-import alien4cloud.tosca.context.ToscaContext;
-import alien4cloud.tosca.model.ArchiveRoot;
-import alien4cloud.tosca.parser.*;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import lombok.extern.slf4j.Slf4j;
-import org.alien4cloud.tosca.catalog.repository.CsarFileRepository;
-import org.alien4cloud.tosca.model.Csar;
-import org.alien4cloud.tosca.model.definitions.DeploymentArtifact;
-import org.alien4cloud.tosca.model.templates.NodeTemplate;
-import org.alien4cloud.tosca.model.templates.ServiceNodeTemplate;
-import org.springframework.stereotype.Component;
+import static com.google.common.io.Files.copy;
 
-import javax.annotation.Resource;
-import javax.inject.Inject;
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
@@ -35,7 +17,34 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipOutputStream;
 
-import static com.google.common.io.Files.copy;
+import javax.annotation.Resource;
+import javax.inject.Inject;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import org.alien4cloud.tosca.catalog.repository.CsarFileRepository;
+import org.alien4cloud.tosca.model.Csar;
+import org.alien4cloud.tosca.model.definitions.DeploymentArtifact;
+import org.alien4cloud.tosca.model.templates.NodeTemplate;
+import org.alien4cloud.tosca.model.templates.ServiceNodeTemplate;
+import org.springframework.stereotype.Component;
+
+import alien4cloud.component.ICSARRepositorySearchService;
+import alien4cloud.model.components.CSARSource;
+import alien4cloud.model.deployment.DeploymentTopology;
+import alien4cloud.paas.model.PaaSNodeTemplate;
+import alien4cloud.paas.model.PaaSTopology;
+import alien4cloud.paas.model.PaaSTopologyDeploymentContext;
+import alien4cloud.paas.yorc.tosca.model.templates.YorcServiceNodeTemplate;
+import alien4cloud.tosca.context.ToscaContext;
+import alien4cloud.tosca.model.ArchiveRoot;
+import alien4cloud.tosca.parser.ParsingError;
+import alien4cloud.tosca.parser.ParsingErrorLevel;
+import alien4cloud.tosca.parser.ParsingException;
+import alien4cloud.tosca.parser.ParsingResult;
+import alien4cloud.tosca.parser.ToscaParser;
+import lombok.extern.slf4j.Slf4j;
 
 
 @Slf4j
@@ -104,7 +113,7 @@ public class ZipBuilder {
 
             // Get the yaml of the application as built by from a4c
             DeploymentTopology dtopo = context.getDeploymentTopology();
-            Csar myCsar = new Csar(context.getDeploymentPaaSId(), dtopo.getArchiveVersion());
+            Csar myCsar = new Csar(dtopo.getArchiveName(), dtopo.getArchiveVersion());
             myCsar.setToscaDefinitionsVersion(ToscaParser.LATEST_DSL);
             String yaml = toscaTopologyExporter.getYaml(myCsar, dtopo, true, artifactMap);
             zos.write(yaml.getBytes(Charset.forName("UTF-8")));

--- a/src/main/resources/alien4cloud/paas/yorc/tosca/topology-alien_dsl_2_0_0.yml.vm
+++ b/src/main/resources/alien4cloud/paas/yorc/tosca/topology-alien_dsl_2_0_0.yml.vm
@@ -151,7 +151,7 @@ ${utils.formatArtifact($artifactEntry.value, 8)}
 #else
                 ${operationEntry.key}:
 #if($utils.mapIsNotEmptyAndContainsNotnullValues($operationEntry.value.inputParameters))
-                  input:$propertyUtils.formatProperties(7, $operationEntry.value.inputParameters)
+                  inputs:$propertyUtils.formatProperties(7, $operationEntry.value.inputParameters)
 #end
                   implementation:
 ${utils.formatArtifact($operationEntry.value.implementationArtifact, 10)}
@@ -185,7 +185,7 @@ ${utils.formatArtifact($operationEntry.value.implementationArtifact, 10)}
 #else
           ${operationEntry.key}:
 #if($utils.mapIsNotEmptyAndContainsNotnullValues($operationEntry.value.inputParameters))
-            input:$propertyUtils.formatProperties(7, $operationEntry.value.inputParameters)
+            inputs:$propertyUtils.formatProperties(7, $operationEntry.value.inputParameters)
 #end
             implementation:
 ${utils.formatArtifact($operationEntry.value.implementationArtifact, 7)}

--- a/src/main/resources/slurm/resources/resources.yaml
+++ b/src/main/resources/slurm/resources/resources.yaml
@@ -13,6 +13,7 @@ imports:
   - tosca-normative-types:${tosca.normative.types.version}
   - alien-base-types:${project.version}
   - yorc-types:${yorc.types.version}
+  - docker-types:${project.version}
 
 
 artifact_types:
@@ -227,3 +228,9 @@ node_types:
         description: Print all debug and verbose information during singularity execution
         required: false
         default: false
+
+  yorc.nodes.slurm.ContainerRuntime:
+    derived_from: org.alien4cloud.extended.container.types.ContainerRuntime
+
+  yorc.nodes.slurm.ContainerJobUnit:
+    derived_from: org.alien4cloud.extended.container.types.ContainerJobUnit

--- a/src/main/resources/slurm/resources/resources.yaml
+++ b/src/main/resources/slurm/resources/resources.yaml
@@ -234,3 +234,11 @@ node_types:
 
   yorc.nodes.slurm.ContainerJobUnit:
     derived_from: org.alien4cloud.extended.container.types.ContainerJobUnit
+
+  yorc.nodes.slurm.HostToContainerVolume:
+    derived_from: org.alien4cloud.nodes.DockerExtVolume
+    properties:
+      path:
+        type: string
+        description: |
+          Path of the directory on the host.

--- a/src/main/resources/slurm/resources/resources.yaml
+++ b/src/main/resources/slurm/resources/resources.yaml
@@ -242,3 +242,9 @@ node_types:
         type: string
         description: |
           Path of the directory on the host.
+      readOnly:
+        type: boolean
+        description: |
+          Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+        default: false
+        required: false


### PR DESCRIPTION
# Pull Request description

## Description of the change

This PR adds a topology modifier that allow to transform a topology composed of docker jobs into a Slurm+Singularity topology. This is pretty much the equivalent of the Kubernetes modifier plugin that transform topologies composed of docker models into kubernetes applications.

This modifier supports only Jobs (deployments and statefulsets are not supported ATM).

### What I did

Transform `org.alien4cloud.extended.container.types.ContainerRuntime`, `org.alien4cloud.extended.container.types.ContainerJobUnit` and `tosca.nodes.Container.Application.DockerContainer` into a `yorc.nodes.slurm.SingularityJob` 

### How I did it

Everything is done within a single modifier: `docker-to-singularity-modifier`.
We added 3 new types in the Slurm location:   

* `yorc.nodes.slurm.ContainerRuntime` derived from `org.alien4cloud.extended.container.types.ContainerRuntime`
* `yorc.nodes.slurm.ContainerJobUnit` derived from `org.alien4cloud.extended.container.types.ContainerJobUnit`
* `yorc.nodes.slurm.HostToContainerVolume` derived from `org.alien4cloud.nodes.DockerExtVolume` this allows to mount a path from the host running the Singularity container into the container.

Those nodes are used only for matching. The modifier runs on `post_node_match` and transform those nodes into a `yorc.nodes.slurm.SingularityJob` 

### How to verify it

The following samples allows to demonstrate complex job orchestration that could be run on Kubernetes and Singularity/Slurm. https://github.com/ystia/tosca-samples/tree/develop/org/ystia/yorc/samples/job/text-count-demo

This sample is composed in 4 parts:
1. A `WebScraper` job downloads a file from an url and save it into a directory backed to an external volume. This volume should be matched against a  `yorc.nodes.slurm.HostToContainerVolume` and should be backed to a NFS directory on Slurm.
2. Then two jobs `LineCount̀` & `WordCount` are run in parallel they read the downloaded file from their volumes and compute the desired counts. Finally they output a resulting file.
3. Finally a `GCPBucketPublisher` job is run and copy the results files to a GCP Bucket.

The GCP bucket publishing may be tricky to implement as the GCP service account file should be provided into the `GCPSecret` volume. That mean that your service account file should be present on your nfs filesystem. This part can be removed or replaced by another simplest computation if needed.

Things to verify are:

* [ ] Jobs are properly sequenced

```
                               +------------------+
                               |                  |
                         +---->+   LineCount      +-----+
+------------------+     |     |                  |     |      +----------------------+
|                  |     |     -------------------+     |      |                      |
|   WebScraper     +-----+                              +----->+  GCPBucketPublisher  |
|                  |     |     +------------------+     |      |                      |
+------------------+     |     |                  |     |      +----------------------+
                         +---->+   WordCount      +-----+
                               |                  |
                               +------------------+
```
* [ ] Requested memory is propagated to Slurm (can be checked by `scontrol show job`). Memory limit is taken from the `mem_size` property of the `org.alien4cloud.extended.container.capabilities.ApplicationHost` capability on `org.alien4cloud.extended.container.types.ContainerRuntime`s 
* [ ] Requested CPU is propagated to Slurm (can be checked by `scontrol show job`). CPUs limit is taken from the `num_cpus` property of the `org.alien4cloud.extended.container.capabilities.ApplicationHost` capability on `org.alien4cloud.extended.container.types.ContainerRuntime`s 

