### PR TITLE
Allow to extend docker2singularity modifier

### DIFF
--- a/src/main/java/alien4cloud/paas/yorc/modifier/LocationCreationListener.java
+++ b/src/main/java/alien4cloud/paas/yorc/modifier/LocationCreationListener.java
@@ -75,7 +75,8 @@ public class LocationCreationListener implements ApplicationListener<AfterLocati
         kubernetesTopologyModifierRef = new LocationModifierReference();
         kubernetesTopologyModifierRef.setPluginId("alien4cloud-kubernetes-plugin");
         kubernetesTopologyModifierRef.setBeanName("kubernetes-modifier");
-        kubernetesTopologyModifierRef.setPhase(FlowPhases.POST_LOCATION_MATCH);
+        // Set this modifier to PRE_POLICY_MATCH in order to trigger it after having replaced get_input functions
+        kubernetesTopologyModifierRef.setPhase(FlowPhases.PRE_POLICY_MATCH);
 
         googleAddressModifierRef = new LocationModifierReference();
         googleAddressModifierRef.setPluginId(selfContext.getPlugin().getId());

--- a/src/main/resources/META-INF/plugin.yml
+++ b/src/main/resources/META-INF/plugin.yml
@@ -19,5 +19,8 @@ component_descriptors:
   - bean_name: yorc-monitoring-modifier
     name: Yorc modifier for handling monitoring policies
     description: Yorc modifier for handling monitoring policies
+  - bean_name: docker-to-singularity-modifier
+    name: Yorc modifier for transforming Docker Jobs into Singularity/Slurm Jobs
+    description: Yorc modifier for transforming Docker Jobs into Singularity/Slurm Jobs
 dependencies:
   - alien4cloud-kubernetes-plugin

--- a/src/main/resources/slurm/resources/resources.yaml
+++ b/src/main/resources/slurm/resources/resources.yaml
@@ -191,6 +191,12 @@ node_types:
           Time interval duration used for job monitoring as "5s" or "300ms"
           Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
         required: false
+      environment_file:
+        type: string
+        required: false
+        description: >
+          If specified and present on the client node the given file will be sourced before submitting the job.
+          This is useful when user-specific variables are required.
       credentials:
         type: tosca.datatypes.Credential
         description: >

--- a/src/main/resources/slurm/resources/resources.yaml
+++ b/src/main/resources/slurm/resources/resources.yaml
@@ -101,6 +101,14 @@ data_types:
         required: false
         entry_schema:
           type: string
+      in_script_options:
+        type: list
+        description: |
+          List of options to be passed to sbatch as inline batch script options.
+          To be valid each element should start with a dash '#' character.
+        required: false
+        entry_schema:
+          type: string
 
 
 capability_types:


### PR DESCRIPTION
This PR refactors the docker2singularity modifier to make it extendable & reusable for specific integrations like Atos specific integration of Singularity & Slurm.

This PR also allow to model options to be passed to sbatch as inline batch script options.

Also support sourcing of an env file before submitting slurm jobs (fixes ystia/yorc#541)