### PR TITLE
Take into account yorc API changes on updates

### DIFF
--- a/src/main/java/alien4cloud/paas/yorc/context/rest/DeploymentClient.java
+++ b/src/main/java/alien4cloud/paas/yorc/context/rest/DeploymentClient.java
@@ -1,8 +1,5 @@
 package alien4cloud.paas.yorc.context.rest;
 
-import alien4cloud.paas.model.NodeOperationExecRequest;
-
-import io.reactivex.Completable;
 import org.json.JSONObject;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -11,15 +8,14 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
+import alien4cloud.paas.model.NodeOperationExecRequest;
 import alien4cloud.paas.yorc.context.rest.response.AllDeploymentsDTO;
 import alien4cloud.paas.yorc.context.rest.response.DeploymentDTO;
-import alien4cloud.paas.yorc.context.rest.response.Link;
 import alien4cloud.paas.yorc.util.RestUtil;
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.Optional;
 
 @Slf4j
 @Component
@@ -30,9 +26,10 @@ public class DeploymentClient extends AbstractClient {
      *
      * @param deploymentId
      * @param bytes zip file as bytes
+     * @param isUpdate if true perform an update on an existing deployment, otherwise submit a new one
      * @return
      */
-    public Single<ResponseEntity<String>> sendTopology(String deploymentId, byte[] bytes) {
+    public Single<ResponseEntity<String>> sendTopology(String deploymentId, byte[] bytes, boolean isUpdate) {
         String url = getYorcUrl() + "/deployments/" + deploymentId;
 
         HttpHeaders headers = new HttpHeaders();
@@ -40,7 +37,12 @@ public class DeploymentClient extends AbstractClient {
         headers.add(HttpHeaders.CONTENT_TYPE, "application/zip");
         HttpEntity<byte[]> entity = new HttpEntity<>(bytes, headers);
 
-        return sendRequest(url,HttpMethod.PUT,String.class,entity);
+        HttpMethod method = HttpMethod.PUT;
+        if (isUpdate) {
+            method = HttpMethod.PATCH;
+        }
+
+        return sendRequest(url, method, String.class, entity);
     }
 
     /**

--- a/src/main/java/alien4cloud/paas/yorc/context/service/fsm/FsmActions.java
+++ b/src/main/java/alien4cloud/paas/yorc/context/service/fsm/FsmActions.java
@@ -1,5 +1,23 @@
 package alien4cloud.paas.yorc.context.service.fsm;
 
+import java.io.IOException;
+import java.util.Date;
+import java.util.Iterator;
+
+import javax.annotation.Resource;
+import javax.inject.Inject;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.alien4cloud.tosca.normative.constants.NormativeWorkflowNameConstants;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.Message;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
 import alien4cloud.paas.IPaaSCallback;
 import alien4cloud.paas.model.PaaSDeploymentLog;
 import alien4cloud.paas.model.PaaSDeploymentLogLevel;
@@ -15,23 +33,8 @@ import alien4cloud.paas.yorc.context.service.InstanceInformationService;
 import alien4cloud.paas.yorc.context.service.LogEventService;
 import alien4cloud.paas.yorc.service.ZipBuilder;
 import alien4cloud.paas.yorc.util.RestUtil;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.jsonwebtoken.lang.Collections;
 import lombok.extern.slf4j.Slf4j;
-import org.alien4cloud.tosca.normative.constants.NormativeWorkflowNameConstants;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.Message;
-import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.action.Action;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
-
-import javax.annotation.Resource;
-import javax.inject.Inject;
-import java.io.IOException;
-import java.util.Date;
-import java.util.Iterator;
 
 @Slf4j
 @Service
@@ -127,7 +130,7 @@ public class FsmActions {
 					return;
 				}
 
-				deploymentClient.sendTopology(context.getDeploymentPaaSId(), bytes).subscribe(this::onHttpOk, this::onHttpKo);
+				deploymentClient.sendTopology(context.getDeploymentPaaSId(), bytes, false).subscribe(this::onHttpOk, this::onHttpKo);
 			}
 		};
 	}
@@ -411,7 +414,7 @@ public class FsmActions {
 					return;
 				}
 
-				deploymentClient.sendTopology(context.getDeploymentPaaSId(), bytes).subscribe(this::onHttpOk, this::onHttpKo);
+				deploymentClient.sendTopology(context.getDeploymentPaaSId(), bytes, true).subscribe(this::onHttpOk, this::onHttpKo);
 			}
 		};
 	}


### PR DESCRIPTION
This PR requires ystia/yorc#549 to be merged

This PR takes into account a change that makes the update deployments endpoint a separate endpoint.
Until now the same endpoint was used to deploy a new topology and to update an existing one.