### PR TITLE
Added OpenStack compute instance netadata property

### DIFF
--- a/src/main/resources/openstack/resources/resources.yaml
+++ b/src/main/resources/openstack/resources/resources.yaml
@@ -156,6 +156,12 @@ node_types:
         description: >
           Coma separated list of security groups to add to the Compute
         required: false
+      metadata:
+        type: map
+        description: Metadata key/value pairs to make available from within the instance
+        entry_schema:
+          type: string
+        required: false
     requirements:
       - group:
           capability: yorc.capabilities.Group


### PR DESCRIPTION
The OpenStack API provides a Compute Instance property metadata allowing a user to define key/value pairs at instance creation, and these key/value pairs will then be available from within the instance.
Added the corresponding property in Yorc TOSCA type for OpenStack compute instances.

To test it, see corresponding pull request on Yorc: https://github.com/ystia/yorc/pull/694

Closes #22