### PR TITLE
Added boot device property volume_type

### DIFF
--- a/src/main/resources/openstack/resources/resources.yaml
+++ b/src/main/resources/openstack/resources/resources.yaml
@@ -41,6 +41,10 @@ data_types:
           source=blank and destination=local, or source=blank and destination=volume
         constraints:
           - greater_or_equal: 1 GB
+      volume_type:
+        type: string
+        required: false
+        description: Volume type
       delete_on_termination:
         type: boolean
         required: false


### PR DESCRIPTION
The OpenStack API provides the ability to specify the type of volume to create when creating a compute instance.
Exammple of such need in LEXIS project: when creating a Windows openstack instance, a timeout occurs because the image is much larger than for other operating systems. A specific volume type 'Burst buffer' allows to create a volume much quicker.

The OpenStack TOSCA data type BootVolume has now the corresponding new property volume_type for this.
Related Yorc issue: https://github.com/ystia/yorc/issues/703

Closes #24 
