### PR TITLE
Added openstack compute instance user_data property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <yorc.google.types.version>1.0.0</yorc.google.types.version>
     <yorc.hp.types.version>1.1.0</yorc.hp.types.version>
     <yorc.k8s.types.version>3.1.0</yorc.k8s.types.version>
-    <yorc.os.types.version>3.0.0</yorc.os.types.version>
+    <yorc.os.types.version>3.1.0</yorc.os.types.version>
     <yorc.slurm.types.version>3.0.0</yorc.slurm.types.version>
 
     <!-- Tests -->

--- a/src/main/resources/openstack/resources/resources.yaml
+++ b/src/main/resources/openstack/resources/resources.yaml
@@ -166,6 +166,10 @@ node_types:
         entry_schema:
           type: string
         required: false
+      user_data:
+        type: string
+        description: User data to provide when launching the instance
+        required: false
     requirements:
       - group:
           capability: yorc.capabilities.Group


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added a new property `user_data` to TOSCA type `yorc.nodes.openstack.Compute`

See associated issue on Yorc: https://github.com/ystia/yorc/issues/735

### What I did

`pom.xml`
Increased the openstack types minor version as a new property was added

` src/main/resources/openstack/resources/resources.yaml`
Added a user_data string property


## Applicable Issues

Closes #26
